### PR TITLE
Phase 5: Easter eggs

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,33 +2,48 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { AnimatePresence } from 'framer-motion';
 import Navbar from './components/Navbar';
 import PixelCat from './components/PixelCat';
+import KonamiOverlay from './components/KonamiOverlay';
 import Home from './pages/Home';
 import Projects from './pages/Projects';
 import Hobbies from './pages/Hobbies';
 import Resume from './pages/Resume';
 import Homelab from './pages/Homelab';
+import Credits from './pages/Credits';
+import { useKonamiCode } from './hooks/useKonamiCode';
+import { useCrtEffect } from './hooks/useCrtEffect';
+
+function AppContent() {
+  const { activated, dismiss } = useKonamiCode();
+  const { crtEnabled, toggleCrt } = useCrtEffect();
+
+  return (
+    <div className="min-h-screen bg-rpg-void text-rpg-text grid-bg relative">
+      {crtEnabled && <div className="crt-overlay" aria-hidden="true" />}
+
+      <Navbar onToggleCrt={toggleCrt} crtEnabled={crtEnabled} />
+      <main className="max-w-5xl mx-auto px-4 py-8 mt-14">
+        <AnimatePresence mode="wait">
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/projects" element={<Projects />} />
+            <Route path="/hobbies" element={<Hobbies />} />
+            <Route path="/resume" element={<Resume />} />
+            <Route path="/homelab" element={<Homelab />} />
+            <Route path="/credits" element={<Credits />} />
+          </Routes>
+        </AnimatePresence>
+      </main>
+
+      <PixelCat />
+      <KonamiOverlay visible={activated} onDismiss={dismiss} />
+    </div>
+  );
+}
 
 function App() {
   return (
     <Router>
-      <div className="min-h-screen bg-rpg-void text-rpg-text grid-bg relative">
-        <div className="crt-overlay" aria-hidden="true" />
-
-        <Navbar />
-        <main className="max-w-5xl mx-auto px-4 py-8 mt-14">
-          <AnimatePresence mode="wait">
-            <Routes>
-              <Route path="/" element={<Home />} />
-              <Route path="/projects" element={<Projects />} />
-              <Route path="/hobbies" element={<Hobbies />} />
-              <Route path="/resume" element={<Resume />} />
-              <Route path="/homelab" element={<Homelab />} />
-            </Routes>
-          </AnimatePresence>
-        </main>
-
-        <PixelCat />
-      </div>
+      <AppContent />
     </Router>
   );
 }

--- a/app/src/components/KonamiOverlay.tsx
+++ b/app/src/components/KonamiOverlay.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useNavigate } from 'react-router-dom';
+
+interface KonamiOverlayProps {
+  visible: boolean;
+  onDismiss: () => void;
+}
+
+function KonamiOverlay({ visible, onDismiss }: KonamiOverlayProps) {
+  const navigate = useNavigate();
+  const [particles, setParticles] = useState<Array<{ id: number; x: number; y: number; color: string; size: number }>>([]);
+
+  useEffect(() => {
+    if (!visible) return;
+
+    const colors = ['#00e5ff', '#ff2daa', '#ffd700', '#39ff14', '#4d8cff'];
+    const newParticles = Array.from({ length: 40 }, (_, i) => ({
+      id: i,
+      x: Math.random() * 100,
+      y: Math.random() * 100,
+      color: colors[Math.floor(Math.random() * colors.length)],
+      size: 4 + Math.random() * 8,
+    }));
+    setParticles(newParticles);
+  }, [visible]);
+
+  const handleSecret = () => {
+    onDismiss();
+    navigate('/credits');
+  };
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-[9998] flex items-center justify-center"
+          onClick={onDismiss}
+        >
+          {/* Backdrop */}
+          <div className="absolute inset-0 bg-black/80" />
+
+          {/* Pixel confetti */}
+          {particles.map((p) => (
+            <motion.div
+              key={p.id}
+              className="absolute"
+              style={{
+                left: `${p.x}%`,
+                top: `${p.y}%`,
+                width: p.size,
+                height: p.size,
+                backgroundColor: p.color,
+                imageRendering: 'pixelated',
+              }}
+              initial={{ opacity: 0, scale: 0, y: 0 }}
+              animate={{
+                opacity: [0, 1, 1, 0],
+                scale: [0, 1.5, 1, 0.5],
+                y: [0, -100 - Math.random() * 200],
+                rotate: Math.random() * 720,
+              }}
+              transition={{
+                duration: 2 + Math.random(),
+                delay: Math.random() * 0.5,
+                ease: 'easeOut',
+              }}
+            />
+          ))}
+
+          {/* Message */}
+          <motion.div
+            initial={{ scale: 0.5, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.5, opacity: 0 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 20, delay: 0.2 }}
+            className="relative rpg-border rpg-border-glow-gold p-8 text-center max-w-md mx-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="text-4xl mb-4">🎮</div>
+            <h2 className="font-pixel text-sm text-neon-gold mb-3">
+              ACHIEVEMENT UNLOCKED
+            </h2>
+            <p className="font-pixel text-[8px] text-rpg-text-dim mb-2">
+              ↑ ↑ ↓ ↓ ← → ← → B A
+            </p>
+            <p className="font-body text-sm text-rpg-text mb-6">
+              You found the secret! Not many adventurers make it this far.
+            </p>
+            <div className="flex gap-3 justify-center">
+              <button
+                onClick={handleSecret}
+                className="font-pixel text-[9px] uppercase px-4 py-2 border-2 border-neon-gold/60 bg-neon-gold/10 text-neon-gold hover:bg-neon-gold/20 shadow-[3px_3px_0_rgba(255,215,0,0.3)] active:shadow-[1px_1px_0_rgba(255,215,0,0.3)] active:translate-x-[2px] active:translate-y-[2px] transition-all"
+              >
+                View Credits
+              </button>
+              <button
+                onClick={onDismiss}
+                className="font-pixel text-[9px] uppercase px-4 py-2 border-2 border-rpg-border bg-rpg-panel text-rpg-text-dim hover:text-rpg-text hover:border-rpg-border-light transition-all"
+              >
+                Close
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+export default KonamiOverlay;

--- a/app/src/components/KonamiOverlay.tsx
+++ b/app/src/components/KonamiOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 
@@ -50,6 +50,10 @@ function KonamiOverlay({ visible, onDismiss }: KonamiOverlayProps) {
     navigate('/credits');
   };
 
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') onDismiss();
+  }, [onDismiss]);
+
   return (
     <AnimatePresence>
       {visible && (
@@ -58,6 +62,10 @@ function KonamiOverlay({ visible, onDismiss }: KonamiOverlayProps) {
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           className="fixed inset-0 z-[9998] flex items-center justify-center"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Achievement unlocked"
+          onKeyDown={handleKeyDown}
           onClick={onDismiss}
         >
           <div className="absolute inset-0 bg-black/80" />

--- a/app/src/components/KonamiOverlay.tsx
+++ b/app/src/components/KonamiOverlay.tsx
@@ -2,6 +2,18 @@ import { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 
+interface Particle {
+  id: number;
+  x: number;
+  y: number;
+  color: string;
+  size: number;
+  targetY: number;
+  rotation: number;
+  duration: number;
+  delay: number;
+}
+
 interface KonamiOverlayProps {
   visible: boolean;
   onDismiss: () => void;
@@ -9,20 +21,28 @@ interface KonamiOverlayProps {
 
 function KonamiOverlay({ visible, onDismiss }: KonamiOverlayProps) {
   const navigate = useNavigate();
-  const [particles, setParticles] = useState<Array<{ id: number; x: number; y: number; color: string; size: number }>>([]);
+  const [particles, setParticles] = useState<Particle[]>([]);
 
   useEffect(() => {
-    if (!visible) return;
+    if (!visible) {
+      setParticles([]);
+      return;
+    }
 
     const colors = ['#00e5ff', '#ff2daa', '#ffd700', '#39ff14', '#4d8cff'];
-    const newParticles = Array.from({ length: 40 }, (_, i) => ({
-      id: i,
-      x: Math.random() * 100,
-      y: Math.random() * 100,
-      color: colors[Math.floor(Math.random() * colors.length)],
-      size: 4 + Math.random() * 8,
-    }));
-    setParticles(newParticles);
+    setParticles(
+      Array.from({ length: 40 }, (_, i) => ({
+        id: i,
+        x: Math.random() * 100,
+        y: Math.random() * 100,
+        color: colors[Math.floor(Math.random() * colors.length)],
+        size: 4 + Math.random() * 8,
+        targetY: -100 - Math.random() * 200,
+        rotation: Math.random() * 720,
+        duration: 2 + Math.random(),
+        delay: Math.random() * 0.5,
+      })),
+    );
   }, [visible]);
 
   const handleSecret = () => {
@@ -40,10 +60,8 @@ function KonamiOverlay({ visible, onDismiss }: KonamiOverlayProps) {
           className="fixed inset-0 z-[9998] flex items-center justify-center"
           onClick={onDismiss}
         >
-          {/* Backdrop */}
           <div className="absolute inset-0 bg-black/80" />
 
-          {/* Pixel confetti */}
           {particles.map((p) => (
             <motion.div
               key={p.id}
@@ -60,18 +78,17 @@ function KonamiOverlay({ visible, onDismiss }: KonamiOverlayProps) {
               animate={{
                 opacity: [0, 1, 1, 0],
                 scale: [0, 1.5, 1, 0.5],
-                y: [0, -100 - Math.random() * 200],
-                rotate: Math.random() * 720,
+                y: [0, p.targetY],
+                rotate: p.rotation,
               }}
               transition={{
-                duration: 2 + Math.random(),
-                delay: Math.random() * 0.5,
+                duration: p.duration,
+                delay: p.delay,
                 ease: 'easeOut',
               }}
             />
           ))}
 
-          {/* Message */}
           <motion.div
             initial={{ scale: 0.5, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}

--- a/app/src/components/Navbar.tsx
+++ b/app/src/components/Navbar.tsx
@@ -10,7 +10,12 @@ const navItems = [
   { to: '/homelab', label: 'Base', icon: '🏰' },
 ];
 
-function Navbar() {
+interface NavbarProps {
+  onToggleCrt?: () => void;
+  crtEnabled?: boolean;
+}
+
+function Navbar({ onToggleCrt, crtEnabled }: NavbarProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   return (
@@ -65,13 +70,25 @@ function Navbar() {
             ))}
 
             {/* Party Members indicator */}
-            <div className="ml-4 pl-4 border-l border-rpg-border flex items-center gap-2">
-              <span className="font-pixel text-[8px] text-rpg-text-dim">PARTY</span>
-              <div className="flex gap-0.5">
-                <span className="text-[10px]">👤</span>
-                <span className="text-[10px]">👤</span>
-                <span className="text-[8px]">👶</span>
+            <div className="ml-4 pl-4 border-l border-rpg-border flex items-center gap-3">
+              <div className="flex items-center gap-2">
+                <span className="font-pixel text-[8px] text-rpg-text-dim">PARTY</span>
+                <div className="flex gap-0.5">
+                  <span className="text-[10px]">👤</span>
+                  <span className="text-[10px]">👤</span>
+                  <span className="text-[8px]">👶</span>
+                </div>
               </div>
+              {onToggleCrt && (
+                <button
+                  onClick={onToggleCrt}
+                  className="font-pixel text-[7px] text-rpg-text-dim hover:text-rpg-text transition-colors"
+                  title={crtEnabled ? 'Disable CRT effect' : 'Enable CRT effect'}
+                  aria-label={crtEnabled ? 'Disable CRT effect' : 'Enable CRT effect'}
+                >
+                  {crtEnabled ? '📺' : '🖥️'}
+                </button>
+              )}
             </div>
           </div>
 

--- a/app/src/components/Navbar.tsx
+++ b/app/src/components/Navbar.tsx
@@ -154,13 +154,24 @@ function Navbar({ onToggleCrt, crtEnabled }: NavbarProps) {
                   ))}
                 </div>
 
-                {/* Party Members in mobile */}
-                <div className="mt-8 pt-4 border-t border-rpg-border">
-                  <div className="font-pixel text-[8px] text-rpg-text-dim mb-2">PARTY MEMBERS</div>
-                  <div className="flex items-center gap-2 text-sm">
-                    <span>👤</span><span>👤</span><span>👶</span>
-                    <span className="font-pixel text-[8px] text-rpg-text-dim ml-2">× 3</span>
+                {/* Party Members + CRT toggle in mobile */}
+                <div className="mt-8 pt-4 border-t border-rpg-border space-y-4">
+                  <div>
+                    <div className="font-pixel text-[8px] text-rpg-text-dim mb-2">PARTY MEMBERS</div>
+                    <div className="flex items-center gap-2 text-sm">
+                      <span>👤</span><span>👤</span><span>👶</span>
+                      <span className="font-pixel text-[8px] text-rpg-text-dim ml-2">× 3</span>
+                    </div>
                   </div>
+                  {onToggleCrt && (
+                    <button
+                      onClick={onToggleCrt}
+                      className="flex items-center gap-2 font-pixel text-[8px] text-rpg-text-dim hover:text-rpg-text transition-colors"
+                    >
+                      <span>{crtEnabled ? '📺' : '🖥️'}</span>
+                      <span>CRT {crtEnabled ? 'ON' : 'OFF'}</span>
+                    </button>
+                  )}
                 </div>
               </div>
             </motion.div>

--- a/app/src/hooks/useCrtEffect.ts
+++ b/app/src/hooks/useCrtEffect.ts
@@ -1,0 +1,19 @@
+import { useState, useCallback } from 'react';
+
+export function useCrtEffect() {
+  const [enabled, setEnabled] = useState(() => {
+    if (typeof window === 'undefined') return true;
+    const stored = localStorage.getItem('crt-effect');
+    return stored === null ? true : stored === 'true';
+  });
+
+  const toggle = useCallback(() => {
+    setEnabled((prev) => {
+      const next = !prev;
+      localStorage.setItem('crt-effect', String(next));
+      return next;
+    });
+  }, []);
+
+  return { crtEnabled: enabled, toggleCrt: toggle };
+}

--- a/app/src/hooks/useKonamiCode.ts
+++ b/app/src/hooks/useKonamiCode.ts
@@ -34,6 +34,7 @@ export function useKonamiCode() {
           reset();
         }
       } else {
+        clearTimeout(timerRef.current);
         reset();
       }
     };

--- a/app/src/hooks/useKonamiCode.ts
+++ b/app/src/hooks/useKonamiCode.ts
@@ -29,6 +29,7 @@ export function useKonamiCode() {
         timerRef.current = setTimeout(reset, 2000);
 
         if (indexRef.current === KONAMI_SEQUENCE.length) {
+          clearTimeout(timerRef.current);
           setActivated(true);
           reset();
         }

--- a/app/src/hooks/useKonamiCode.ts
+++ b/app/src/hooks/useKonamiCode.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+const KONAMI_SEQUENCE = [
+  'ArrowUp', 'ArrowUp',
+  'ArrowDown', 'ArrowDown',
+  'ArrowLeft', 'ArrowRight',
+  'ArrowLeft', 'ArrowRight',
+  'b', 'a',
+];
+
+export function useKonamiCode() {
+  const [activated, setActivated] = useState(false);
+  const indexRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const reset = useCallback(() => {
+    indexRef.current = 0;
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      const expected = KONAMI_SEQUENCE[indexRef.current];
+
+      if (e.key === expected || e.key.toLowerCase() === expected) {
+        indexRef.current++;
+
+        // Reset if no input within 2 seconds
+        clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(reset, 2000);
+
+        if (indexRef.current === KONAMI_SEQUENCE.length) {
+          setActivated(true);
+          reset();
+        }
+      } else {
+        reset();
+      }
+    };
+
+    window.addEventListener('keydown', handleKey);
+    return () => {
+      window.removeEventListener('keydown', handleKey);
+      clearTimeout(timerRef.current);
+    };
+  }, [reset]);
+
+  const dismiss = useCallback(() => setActivated(false), []);
+
+  return { activated, dismiss };
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -43,13 +43,19 @@
   position: fixed;
   inset: 0;
   z-index: 9999;
-  background: repeating-linear-gradient(
-    0deg,
-    transparent,
-    transparent 2px,
-    rgba(0, 0, 0, 0.03) 2px,
-    rgba(0, 0, 0, 0.03) 4px
-  );
+  background:
+    repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 2px,
+      rgba(0, 0, 0, 0.12) 2px,
+      rgba(0, 0, 0, 0.12) 4px
+    ),
+    radial-gradient(
+      ellipse at center,
+      transparent 60%,
+      rgba(0, 0, 0, 0.3) 100%
+    );
 }
 
 /* ═══════════════════════════════════════

--- a/app/src/pages/Credits.tsx
+++ b/app/src/pages/Credits.tsx
@@ -1,0 +1,86 @@
+import { motion } from 'framer-motion';
+import PageTransition from '../components/PageTransition';
+import PixelPanel from '../components/ui/PixelPanel';
+
+const credits = [
+  {
+    section: 'Created By',
+    entries: ['Juan Garces', 'Site Reliability Mage', 'Medellín → Florida'],
+  },
+  {
+    section: 'Built With',
+    entries: ['React', 'TypeScript', 'Vite', 'Tailwind CSS', 'Framer Motion'],
+  },
+  {
+    section: 'Deployed On',
+    entries: ['Cloudflare Workers', 'GitHub Actions'],
+  },
+  {
+    section: 'Powered By',
+    entries: ['Colombian coffee ☕', 'Late night debugging sessions', 'An unhealthy amount of anime'],
+  },
+  {
+    section: 'Infrastructure',
+    entries: ['K3s cluster across 2 countries', 'Tailscale VPN', '~140TB of storage', 'One very loud Lenovo P520'],
+  },
+  {
+    section: 'Special Thanks',
+    entries: ['The open-source community', 'Stack Overflow (obviously)', 'My family for tolerating the server noise'],
+  },
+  {
+    section: 'Party Members',
+    entries: ['👤 Juan — Lead Adventurer', '👤 Wife — Support Healer', '👶 Kid — Chaos Agent'],
+  },
+  {
+    section: 'Easter Egg Found By',
+    entries: ['You! Thanks for exploring.', '↑ ↑ ↓ ↓ ← → ← → B A'],
+  },
+];
+
+function Credits() {
+  return (
+    <PageTransition>
+      <div className="max-w-2xl mx-auto space-y-2 pb-20">
+        <PixelPanel glow="gold" className="text-center py-8 mb-8">
+          <span className="text-3xl block mb-3">🏆</span>
+          <h1 className="font-pixel text-lg text-neon-gold mb-2">Credits</h1>
+          <p className="font-pixel text-[8px] text-rpg-text-dim">
+            — THE END? —
+          </p>
+        </PixelPanel>
+
+        {credits.map((block, i) => (
+          <motion.div
+            key={block.section}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.5 + i * 0.3, duration: 0.6 }}
+            className="text-center py-4"
+          >
+            <h2 className="font-pixel text-[10px] text-neon-cyan uppercase mb-3">
+              {block.section}
+            </h2>
+            {block.entries.map((entry, j) => (
+              <p key={j} className="font-body text-sm text-rpg-text leading-relaxed">
+                {entry}
+              </p>
+            ))}
+          </motion.div>
+        ))}
+
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: credits.length * 0.3 + 1 }}
+          className="text-center pt-8 pb-12"
+        >
+          <p className="font-pixel text-[8px] text-rpg-text-dim animate-blink">
+            PRESS START TO CONTINUE...
+          </p>
+        </motion.div>
+      </div>
+    </PageTransition>
+  );
+}
+
+export default Credits;

--- a/app/src/test/hooks/useCrtEffect.test.ts
+++ b/app/src/test/hooks/useCrtEffect.test.ts
@@ -1,0 +1,27 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCrtEffect } from '../../hooks/useCrtEffect';
+
+describe('useCrtEffect', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to enabled', () => {
+    const { result } = renderHook(() => useCrtEffect());
+    expect(result.current.crtEnabled).toBe(true);
+  });
+
+  it('toggles state and persists to localStorage', () => {
+    const { result } = renderHook(() => useCrtEffect());
+    act(() => result.current.toggleCrt());
+    expect(result.current.crtEnabled).toBe(false);
+    expect(localStorage.getItem('crt-effect')).toBe('false');
+  });
+
+  it('reads persisted value from localStorage', () => {
+    localStorage.setItem('crt-effect', 'false');
+    const { result } = renderHook(() => useCrtEffect());
+    expect(result.current.crtEnabled).toBe(false);
+  });
+});

--- a/app/src/test/hooks/useKonamiCode.test.ts
+++ b/app/src/test/hooks/useKonamiCode.test.ts
@@ -1,0 +1,50 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useKonamiCode } from '../../hooks/useKonamiCode';
+
+const fireKey = (key: string) => {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key }));
+};
+
+const enterKonamiCode = () => {
+  fireKey('ArrowUp');
+  fireKey('ArrowUp');
+  fireKey('ArrowDown');
+  fireKey('ArrowDown');
+  fireKey('ArrowLeft');
+  fireKey('ArrowRight');
+  fireKey('ArrowLeft');
+  fireKey('ArrowRight');
+  fireKey('b');
+  fireKey('a');
+};
+
+describe('useKonamiCode', () => {
+  it('starts inactive', () => {
+    const { result } = renderHook(() => useKonamiCode());
+    expect(result.current.activated).toBe(false);
+  });
+
+  it('activates on correct sequence', () => {
+    const { result } = renderHook(() => useKonamiCode());
+    act(() => enterKonamiCode());
+    expect(result.current.activated).toBe(true);
+  });
+
+  it('does not activate on wrong sequence', () => {
+    const { result } = renderHook(() => useKonamiCode());
+    act(() => {
+      fireKey('ArrowUp');
+      fireKey('ArrowDown'); // wrong — should be ArrowUp
+    });
+    expect(result.current.activated).toBe(false);
+  });
+
+  it('dismiss resets activated state', () => {
+    const { result } = renderHook(() => useKonamiCode());
+    act(() => enterKonamiCode());
+    expect(result.current.activated).toBe(true);
+    act(() => result.current.dismiss());
+    expect(result.current.activated).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- **Konami code** (↑↑↓↓←→←→BA): pixel confetti explosion + "ACHIEVEMENT UNLOCKED" overlay with link to secret credits
- **Secret /credits page**: RPG end-credits scroll — tech stack, infrastructure, "Party Members" (👤 Juan, 👤 Wife, 👶 Kid — Chaos Agent), easter egg acknowledgment
- **CRT effect toggle**: 📺/🖥️ button in navbar, persisted to localStorage

None of these are discoverable from normal navigation — the credits page is only accessible via Konami code or direct URL.

## Test plan
- [x] `npm run test` — 8 tests pass
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — builds successfully
- [ ] Test Konami code input on desktop
- [ ] Verify CRT toggle persists across page loads
- [ ] Verify /credits page renders with staggered animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)