### PR TITLE
Fix mobile menu scroll lock and auto-close on nav

### DIFF
--- a/app/src/components/KonamiOverlay.tsx
+++ b/app/src/components/KonamiOverlay.tsx
@@ -61,7 +61,8 @@ function KonamiOverlay({ visible, onDismiss }: KonamiOverlayProps) {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          className="fixed inset-0 z-[9998] flex items-center justify-center"
+          className="fixed inset-0 flex items-center justify-center"
+          style={{ zIndex: 'var(--z-konami)' }}
           role="dialog"
           aria-modal="true"
           aria-label="Achievement unlocked"

--- a/app/src/components/Navbar.tsx
+++ b/app/src/components/Navbar.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { NavLink } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { NavLink, useLocation } from 'react-router-dom';
 import { Menu, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 
@@ -17,6 +17,16 @@ interface NavbarProps {
 
 function Navbar({ onToggleCrt, crtEnabled }: NavbarProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    setIsMenuOpen(false);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    document.body.style.overflow = isMenuOpen ? 'hidden' : '';
+    return () => { document.body.style.overflow = ''; };
+  }, [isMenuOpen]);
 
   return (
     <>

--- a/app/src/components/Navbar.tsx
+++ b/app/src/components/Navbar.tsx
@@ -24,8 +24,10 @@ function Navbar({ onToggleCrt, crtEnabled }: NavbarProps) {
   }, [location.pathname]);
 
   useEffect(() => {
-    document.body.style.overflow = isMenuOpen ? 'hidden' : '';
-    return () => { document.body.style.overflow = ''; };
+    if (!isMenuOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = prev; };
   }, [isMenuOpen]);
 
   useEffect(() => {
@@ -112,15 +114,13 @@ function Navbar({ onToggleCrt, crtEnabled }: NavbarProps) {
             </div>
 
             {/* Mobile Menu Button */}
-            <div className="md:hidden relative z-50">
               <button
                 onClick={() => setIsMenuOpen(!isMenuOpen)}
-                className="p-2 text-rpg-text hover:text-neon-cyan transition-colors"
+                className="md:hidden relative z-50 p-2 text-rpg-text hover:text-neon-cyan transition-colors"
                 aria-label="Toggle menu"
               >
                 {isMenuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
               </button>
-            </div>
           </div>
         </div>
       </nav>

--- a/app/src/components/Navbar.tsx
+++ b/app/src/components/Navbar.tsx
@@ -28,95 +28,102 @@ function Navbar({ onToggleCrt, crtEnabled }: NavbarProps) {
     return () => { document.body.style.overflow = ''; };
   }, [isMenuOpen]);
 
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 768px)');
+    const handler = () => { if (mq.matches) setIsMenuOpen(false); };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
   return (
     <>
-    <nav
-      className={`fixed top-0 left-0 right-0 bg-rpg-deep/95 backdrop-blur-sm border-b-2 border-rpg-border shadow-[0_4px_20px_rgba(0,0,0,0.5)] ${isMenuOpen ? 'z-[10002]' : 'z-50'}`}
-    >
-      <div className="max-w-5xl mx-auto px-4">
-        <div className="flex items-center justify-between h-14">
-          {/* Logo / Home */}
-          <NavLink
-            to="/"
-            className="flex items-center gap-2 relative z-50 group"
-            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-          >
-            <span className="text-lg">⚡</span>
-            <span className="font-pixel text-[11px] text-neon-cyan group-hover:text-neon-gold transition-colors">
-              JUAN.EXE
-            </span>
-          </NavLink>
+      <nav
+        className="fixed top-0 left-0 right-0 bg-rpg-deep/95 backdrop-blur-sm border-b-2 border-rpg-border shadow-[0_4px_20px_rgba(0,0,0,0.5)]"
+        style={{ zIndex: isMenuOpen ? 'var(--z-nav-open)' : 'var(--z-nav)' }}
+      >
+        <div className="max-w-5xl mx-auto px-4">
+          <div className="flex items-center justify-between h-14">
+            {/* Logo / Home */}
+            <NavLink
+              to="/"
+              className="flex items-center gap-2 relative z-50 group"
+              onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+            >
+              <span className="text-lg">⚡</span>
+              <span className="font-pixel text-[11px] text-neon-cyan group-hover:text-neon-gold transition-colors">
+                JUAN.EXE
+              </span>
+            </NavLink>
 
-          {/* Desktop Nav */}
-          <div className="hidden md:flex items-center gap-1">
-            {navItems.map((item) => (
-              <NavLink
-                key={item.to}
-                to={item.to}
-                className={({ isActive }) => `
-                  relative flex items-center gap-2 px-4 py-2 font-pixel text-[9px] uppercase tracking-wider
-                  transition-all duration-150
-                  ${isActive
-                    ? 'text-neon-gold bg-neon-gold/5'
-                    : 'text-rpg-text-dim hover:text-rpg-text-bright'
-                  }
-                `}
-              >
-                {({ isActive }) => (
-                  <>
-                    {isActive && (
-                      <motion.span
-                        layoutId="nav-arrow"
-                        className="text-neon-gold text-[8px] animate-arrow-bounce"
-                        transition={{ type: 'spring', stiffness: 400, damping: 30 }}
-                      >
-                        ▶
-                      </motion.span>
-                    )}
-                    <span>{item.icon}</span>
-                    <span>{item.label}</span>
-                  </>
-                )}
-              </NavLink>
-            ))}
-
-            {/* Party Members indicator */}
-            <div className="ml-4 pl-4 border-l border-rpg-border flex items-center gap-3">
-              <div className="flex items-center gap-2">
-                <span className="font-pixel text-[8px] text-rpg-text-dim">PARTY</span>
-                <div className="flex gap-0.5">
-                  <span className="text-[10px]">👤</span>
-                  <span className="text-[10px]">👤</span>
-                  <span className="text-[8px]">👶</span>
-                </div>
-              </div>
-              {onToggleCrt && (
-                <button
-                  onClick={onToggleCrt}
-                  className="font-pixel text-[7px] text-rpg-text-dim hover:text-rpg-text transition-colors"
-                  title={crtEnabled ? 'Disable CRT effect' : 'Enable CRT effect'}
-                  aria-label={crtEnabled ? 'Disable CRT effect' : 'Enable CRT effect'}
+            {/* Desktop Nav */}
+            <div className="hidden md:flex items-center gap-1">
+              {navItems.map((item) => (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  className={({ isActive }) => `
+                    relative flex items-center gap-2 px-4 py-2 font-pixel text-[9px] uppercase tracking-wider
+                    transition-all duration-150
+                    ${isActive
+                      ? 'text-neon-gold bg-neon-gold/5'
+                      : 'text-rpg-text-dim hover:text-rpg-text-bright'
+                    }
+                  `}
                 >
-                  {crtEnabled ? '📺' : '🖥️'}
-                </button>
-              )}
+                  {({ isActive }) => (
+                    <>
+                      {isActive && (
+                        <motion.span
+                          layoutId="nav-arrow"
+                          className="text-neon-gold text-[8px] animate-arrow-bounce"
+                          transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+                        >
+                          ▶
+                        </motion.span>
+                      )}
+                      <span>{item.icon}</span>
+                      <span>{item.label}</span>
+                    </>
+                  )}
+                </NavLink>
+              ))}
+
+              {/* Party Members indicator */}
+              <div className="ml-4 pl-4 border-l border-rpg-border flex items-center gap-3">
+                <div className="flex items-center gap-2">
+                  <span className="font-pixel text-[8px] text-rpg-text-dim">PARTY</span>
+                  <div className="flex gap-0.5">
+                    <span className="text-[10px]">👤</span>
+                    <span className="text-[10px]">👤</span>
+                    <span className="text-[8px]">👶</span>
+                  </div>
+                </div>
+                {onToggleCrt && (
+                  <button
+                    onClick={onToggleCrt}
+                    className="font-pixel text-[7px] text-rpg-text-dim hover:text-rpg-text transition-colors"
+                    title={crtEnabled ? 'Disable CRT effect' : 'Enable CRT effect'}
+                    aria-label={crtEnabled ? 'Disable CRT effect' : 'Enable CRT effect'}
+                  >
+                    {crtEnabled ? '📺' : '🖥️'}
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Mobile Menu Button */}
+            <div className="md:hidden relative z-50">
+              <button
+                onClick={() => setIsMenuOpen(!isMenuOpen)}
+                className="p-2 text-rpg-text hover:text-neon-cyan transition-colors"
+                aria-label="Toggle menu"
+              >
+                {isMenuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+              </button>
             </div>
           </div>
-
-          {/* Mobile Menu Button */}
-          <div className="md:hidden relative z-50">
-            <button
-              onClick={() => setIsMenuOpen(!isMenuOpen)}
-              className="p-2 text-rpg-text hover:text-neon-cyan transition-colors"
-              aria-label="Toggle menu"
-            >
-              {isMenuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
-            </button>
-          </div>
         </div>
-      </div>
-
-    </nav>
+      </nav>
 
       {/* Mobile Menu — RPG Inventory Style (outside nav to escape its stacking context) */}
       <AnimatePresence>
@@ -126,7 +133,8 @@ function Navbar({ onToggleCrt, crtEnabled }: NavbarProps) {
               initial={{ opacity: 0 }}
               animate={{ opacity: 0.7 }}
               exit={{ opacity: 0 }}
-              className="fixed inset-0 bg-black md:hidden z-[10000]"
+              className="fixed inset-0 bg-black md:hidden"
+              style={{ zIndex: 'var(--z-menu-backdrop)' }}
               onClick={() => setIsMenuOpen(false)}
             />
 
@@ -135,7 +143,8 @@ function Navbar({ onToggleCrt, crtEnabled }: NavbarProps) {
               animate={{ x: 0 }}
               exit={{ x: '100%' }}
               transition={{ type: 'tween', duration: 0.25 }}
-              className="fixed top-0 right-0 w-64 h-full md:hidden z-[10001] border-l-2 border-rpg-border bg-[#0f1628]"
+              className="fixed top-0 right-0 w-64 h-full md:hidden border-l-2 border-rpg-border bg-[#0f1628]"
+              style={{ zIndex: 'var(--z-menu-drawer)' }}
             >
               <div className="pt-20 px-4">
                 <div className="font-pixel text-[9px] text-neon-cyan mb-4 pb-2 border-b border-rpg-border uppercase">

--- a/app/src/components/Navbar.tsx
+++ b/app/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { Menu, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -17,18 +17,27 @@ interface NavbarProps {
 
 function Navbar({ onToggleCrt, crtEnabled }: NavbarProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isExitAnimating, setIsExitAnimating] = useState(false);
+  const prevMenuOpen = useRef(false);
   const location = useLocation();
+
+  const isMenuVisible = isMenuOpen || isExitAnimating;
+
+  useEffect(() => {
+    if (prevMenuOpen.current && !isMenuOpen) setIsExitAnimating(true);
+    prevMenuOpen.current = isMenuOpen;
+  }, [isMenuOpen]);
 
   useEffect(() => {
     setIsMenuOpen(false);
   }, [location.pathname]);
 
   useEffect(() => {
-    if (!isMenuOpen) return;
+    if (!isMenuVisible) return;
     const prev = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
     return () => { document.body.style.overflow = prev; };
-  }, [isMenuOpen]);
+  }, [isMenuVisible]);
 
   useEffect(() => {
     const mq = window.matchMedia('(min-width: 768px)');
@@ -126,7 +135,7 @@ function Navbar({ onToggleCrt, crtEnabled }: NavbarProps) {
       </nav>
 
       {/* Mobile Menu — RPG Inventory Style (outside nav to escape its stacking context) */}
-      <AnimatePresence>
+      <AnimatePresence onExitComplete={() => setIsExitAnimating(false)}>
         {isMenuOpen && (
           <>
             <motion.div

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -5,6 +5,19 @@
 @tailwind utilities;
 
 /* ═══════════════════════════════════════
+   Z-INDEX SCALE
+   ═══════════════════════════════════════ */
+
+:root {
+  --z-nav: 50;
+  --z-konami: 9998;
+  --z-crt: 9999;
+  --z-menu-backdrop: 10000;
+  --z-menu-drawer: 10001;
+  --z-nav-open: 10002;
+}
+
+/* ═══════════════════════════════════════
    BASE STYLES — RPG VOID THEME
    ═══════════════════════════════════════ */
 
@@ -42,7 +55,7 @@
   pointer-events: none;
   position: fixed;
   inset: 0;
-  z-index: 9999;
+  z-index: var(--z-crt);
   background:
     repeating-linear-gradient(
       0deg,


### PR DESCRIPTION
## Summary
- Lock `body` scroll (`overflow: hidden`) when mobile menu drawer is open, preventing background content from scrolling underneath
- Auto-close menu on route changes (browser back/forward) via `useLocation` listener
- Cleanup effect restores scroll on unmount

## Test plan
- [ ] Open mobile menu, try scrolling the page behind it — should not scroll
- [ ] Close menu, verify scrolling works normally again
- [ ] Open menu, tap a nav link — menu closes, scroll restored
- [ ] Open menu, use browser back button — menu should auto-close

🤖 Generated with [Claude Code](https://claude.com/claude-code)