### PR TITLE
Add micro-interactions, pixel icons, and Zelda secret easter egg

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -11,9 +11,11 @@ import Homelab from './pages/Homelab';
 import Credits from './pages/Credits';
 import { useKonamiCode } from './hooks/useKonamiCode';
 import { useCrtEffect } from './hooks/useCrtEffect';
+import { useZeldaSecret } from './hooks/useZeldaSecret';
 
 function AppContent() {
-  const { activated, dismiss } = useKonamiCode();
+  const playZeldaSound = useZeldaSecret();
+  const { activated, dismiss } = useKonamiCode(playZeldaSound);
   const { crtEnabled, toggleCrt } = useCrtEffect();
 
   return (

--- a/app/src/components/KonamiOverlay.tsx
+++ b/app/src/components/KonamiOverlay.tsx
@@ -1,18 +1,7 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
-
-interface Particle {
-  id: number;
-  x: number;
-  y: number;
-  color: string;
-  size: number;
-  targetY: number;
-  rotation: number;
-  duration: number;
-  delay: number;
-}
+import { useZeldaSecret } from '../hooks/useZeldaSecret';
 
 interface KonamiOverlayProps {
   visible: boolean;
@@ -21,29 +10,13 @@ interface KonamiOverlayProps {
 
 function KonamiOverlay({ visible, onDismiss }: KonamiOverlayProps) {
   const navigate = useNavigate();
-  const [particles, setParticles] = useState<Particle[]>([]);
+  const playZeldaSound = useZeldaSecret();
 
   useEffect(() => {
-    if (!visible) {
-      setParticles([]);
-      return;
+    if (visible) {
+      playZeldaSound();
     }
-
-    const colors = ['#00e5ff', '#ff2daa', '#ffd700', '#39ff14', '#4d8cff'];
-    setParticles(
-      Array.from({ length: 40 }, (_, i) => ({
-        id: i,
-        x: Math.random() * 100,
-        y: Math.random() * 100,
-        color: colors[Math.floor(Math.random() * colors.length)],
-        size: 4 + Math.random() * 8,
-        targetY: -100 - Math.random() * 200,
-        rotation: Math.random() * 720,
-        duration: 2 + Math.random(),
-        delay: Math.random() * 0.5,
-      })),
-    );
-  }, [visible]);
+  }, [visible, playZeldaSound]);
 
   const handleSecret = () => {
     onDismiss();
@@ -61,6 +34,7 @@ function KonamiOverlay({ visible, onDismiss }: KonamiOverlayProps) {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
+          transition={{ duration: 0.3 }}
           className="fixed inset-0 flex items-center justify-center"
           style={{ zIndex: 'var(--z-konami)' }}
           role="dialog"
@@ -69,54 +43,184 @@ function KonamiOverlay({ visible, onDismiss }: KonamiOverlayProps) {
           onKeyDown={handleKeyDown}
           onClick={onDismiss}
         >
-          <div className="absolute inset-0 bg-black/80" />
+          {/* Dark void that closes in */}
+          <motion.div
+            className="absolute inset-0 bg-black"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.15 }}
+          />
 
-          {particles.map((p) => (
+          {/* Zelda-style spotlight — expanding diamond of light */}
+          <motion.div
+            className="absolute inset-0 flex items-center justify-center pointer-events-none"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.2, duration: 0.3 }}
+          >
+            {/* Radial light burst */}
             <motion.div
-              key={p.id}
               className="absolute"
               style={{
-                left: `${p.x}%`,
-                top: `${p.y}%`,
-                width: p.size,
-                height: p.size,
-                backgroundColor: p.color,
-                imageRendering: 'pixelated',
+                width: 600,
+                height: 600,
+                background: 'radial-gradient(circle, rgba(255,215,0,0.15) 0%, rgba(255,215,0,0.05) 30%, transparent 60%)',
               }}
-              initial={{ opacity: 0, scale: 0, y: 0 }}
-              animate={{
-                opacity: [0, 1, 1, 0],
-                scale: [0, 1.5, 1, 0.5],
-                y: [0, p.targetY],
-                rotate: p.rotation,
-              }}
-              transition={{
-                duration: p.duration,
-                delay: p.delay,
-                ease: 'easeOut',
-              }}
+              initial={{ scale: 0, opacity: 0 }}
+              animate={{ scale: [0, 1.5, 1.2], opacity: [0, 0.8, 0.5] }}
+              transition={{ delay: 0.3, duration: 0.8, ease: 'easeOut' }}
             />
-          ))}
 
+            {/* Spinning diamond sparkles */}
+            {[...Array(8)].map((_, i) => {
+              const angle = (i / 8) * Math.PI * 2;
+              const radius = 80;
+              return (
+                <motion.div
+                  key={i}
+                  className="absolute"
+                  style={{
+                    width: 4,
+                    height: 4,
+                    backgroundColor: '#ffd700',
+                    imageRendering: 'pixelated',
+                    boxShadow: '0 0 6px #ffd700, 0 0 12px rgba(255,215,0,0.4)',
+                  }}
+                  initial={{
+                    x: 0,
+                    y: 0,
+                    opacity: 0,
+                    scale: 0,
+                  }}
+                  animate={{
+                    x: Math.cos(angle) * radius,
+                    y: Math.sin(angle) * radius,
+                    opacity: [0, 1, 0.6],
+                    scale: [0, 2, 1],
+                  }}
+                  transition={{
+                    delay: 0.4 + i * 0.05,
+                    duration: 0.6,
+                    ease: 'easeOut',
+                  }}
+                />
+              );
+            })}
+
+            {/* Vertical light pillar */}
+            <motion.div
+              className="absolute"
+              style={{
+                width: 2,
+                background: 'linear-gradient(180deg, transparent, rgba(255,215,0,0.6), rgba(255,215,0,0.8), rgba(255,215,0,0.6), transparent)',
+              }}
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 300, opacity: 1 }}
+              transition={{ delay: 0.25, duration: 0.4, ease: 'easeOut' }}
+            />
+
+            {/* Horizontal light bar */}
+            <motion.div
+              className="absolute"
+              style={{
+                height: 2,
+                background: 'linear-gradient(90deg, transparent, rgba(255,215,0,0.6), rgba(255,215,0,0.8), rgba(255,215,0,0.6), transparent)',
+              }}
+              initial={{ width: 0, opacity: 0 }}
+              animate={{ width: 300, opacity: 1 }}
+              transition={{ delay: 0.25, duration: 0.4, ease: 'easeOut' }}
+            />
+          </motion.div>
+
+          {/* Pixel sparkle particles */}
+          {[...Array(12)].map((_, i) => {
+            const angle = (i / 12) * Math.PI * 2;
+            const dist = 120 + Math.random() * 80;
+            return (
+              <motion.div
+                key={`sparkle-${i}`}
+                className="absolute"
+                style={{
+                  width: 3,
+                  height: 3,
+                  backgroundColor: i % 3 === 0 ? '#ffd700' : i % 3 === 1 ? '#00e5ff' : '#e8f0ff',
+                  imageRendering: 'pixelated',
+                }}
+                initial={{ opacity: 0, scale: 0, x: 0, y: 0 }}
+                animate={{
+                  opacity: [0, 1, 0],
+                  scale: [0, 1.5, 0],
+                  x: Math.cos(angle) * dist,
+                  y: Math.sin(angle) * dist,
+                }}
+                transition={{
+                  delay: 0.6 + i * 0.04,
+                  duration: 0.8,
+                  ease: 'easeOut',
+                }}
+              />
+            );
+          })}
+
+          {/* Achievement modal */}
           <motion.div
-            initial={{ scale: 0.5, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            exit={{ scale: 0.5, opacity: 0 }}
-            transition={{ type: 'spring', stiffness: 300, damping: 20, delay: 0.2 }}
+            initial={{ scale: 0, opacity: 0, rotateX: 90 }}
+            animate={{ scale: 1, opacity: 1, rotateX: 0 }}
+            exit={{ scale: 0.8, opacity: 0 }}
+            transition={{
+              delay: 0.7,
+              type: 'spring',
+              stiffness: 200,
+              damping: 18,
+            }}
             className="relative rpg-border rpg-border-glow-gold p-8 text-center max-w-md mx-4"
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="text-4xl mb-4">🎮</div>
-            <h2 className="font-pixel text-sm text-neon-gold mb-3">
-              ACHIEVEMENT UNLOCKED
-            </h2>
-            <p className="font-pixel text-[8px] text-rpg-text-dim mb-2">
+            {/* Pixel Triforce icon */}
+            <motion.div
+              className="flex justify-center mb-4"
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              transition={{ delay: 1, type: 'spring', stiffness: 300, damping: 15 }}
+            >
+              <svg viewBox="0 0 32 28" width="40" height="35" style={{ imageRendering: 'pixelated' }}>
+                <polygon points="16,0 24,14 8,14" fill="#ffd700" />
+                <polygon points="8,14 16,28 0,28" fill="#ffd700" />
+                <polygon points="24,14 32,28 16,28" fill="#ffd700" />
+                <polygon points="16,14 20,21 12,21" fill="#0a0e1a" />
+              </svg>
+            </motion.div>
+
+            <motion.h2
+              className="font-pixel text-sm text-neon-gold mb-3"
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 1.1, duration: 0.3 }}
+            >
+              SECRET DISCOVERED
+            </motion.h2>
+            <motion.p
+              className="font-pixel text-[8px] text-rpg-text-dim mb-2"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 1.2 }}
+            >
               ↑ ↑ ↓ ↓ ← → ← → B A
-            </p>
-            <p className="font-body text-sm text-rpg-text mb-6">
+            </motion.p>
+            <motion.p
+              className="font-body text-sm text-rpg-text mb-6"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 1.3 }}
+            >
               You found the secret! Not many adventurers make it this far.
-            </p>
-            <div className="flex gap-3 justify-center">
+            </motion.p>
+            <motion.div
+              className="flex gap-3 justify-center"
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 1.4, duration: 0.3 }}
+            >
               <button
                 onClick={handleSecret}
                 className="font-pixel text-[9px] uppercase px-4 py-2 border-2 border-neon-gold/60 bg-neon-gold/10 text-neon-gold hover:bg-neon-gold/20 shadow-[3px_3px_0_rgba(255,215,0,0.3)] active:shadow-[1px_1px_0_rgba(255,215,0,0.3)] active:translate-x-[2px] active:translate-y-[2px] transition-all"
@@ -129,7 +233,7 @@ function KonamiOverlay({ visible, onDismiss }: KonamiOverlayProps) {
               >
                 Close
               </button>
-            </div>
+            </motion.div>
           </motion.div>
         </motion.div>
       )}

--- a/app/src/components/KonamiOverlay.tsx
+++ b/app/src/components/KonamiOverlay.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useCallback, useMemo } from 'react';
+import { useEffect, useCallback, useMemo, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
-import { useZeldaSecret } from '../hooks/useZeldaSecret';
 
 interface KonamiOverlayProps {
   visible: boolean;
@@ -10,13 +9,14 @@ interface KonamiOverlayProps {
 
 function KonamiOverlay({ visible, onDismiss }: KonamiOverlayProps) {
   const navigate = useNavigate();
-  const playZeldaSound = useZeldaSecret();
+  const dialogRef = useRef<HTMLDivElement>(null);
 
+  // Auto-focus dialog when it opens so Escape key works
   useEffect(() => {
     if (visible) {
-      playZeldaSound();
+      dialogRef.current?.focus();
     }
-  }, [visible, playZeldaSound]);
+  }, [visible]);
 
   const handleSecret = () => {
     onDismiss();
@@ -40,7 +40,9 @@ function KonamiOverlay({ visible, onDismiss }: KonamiOverlayProps) {
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.3 }}
-          className="fixed inset-0 flex items-center justify-center"
+          ref={dialogRef}
+          tabIndex={-1}
+          className="fixed inset-0 flex items-center justify-center outline-none"
           style={{ zIndex: 'var(--z-konami)' }}
           role="dialog"
           aria-modal="true"

--- a/app/src/components/KonamiOverlay.tsx
+++ b/app/src/components/KonamiOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import { useZeldaSecret } from '../hooks/useZeldaSecret';
@@ -22,6 +22,11 @@ function KonamiOverlay({ visible, onDismiss }: KonamiOverlayProps) {
     onDismiss();
     navigate('/credits');
   };
+
+  const sparkleDistances = useMemo(
+    () => Array.from({ length: 12 }, () => 120 + Math.random() * 80),
+    []
+  );
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Escape') onDismiss();
@@ -135,7 +140,7 @@ function KonamiOverlay({ visible, onDismiss }: KonamiOverlayProps) {
           {/* Pixel sparkle particles */}
           {[...Array(12)].map((_, i) => {
             const angle = (i / 12) * Math.PI * 2;
-            const dist = 120 + Math.random() * 80;
+            const dist = sparkleDistances[i];
             return (
               <motion.div
                 key={`sparkle-${i}`}

--- a/app/src/components/ui/PixelIcons.tsx
+++ b/app/src/components/ui/PixelIcons.tsx
@@ -1,0 +1,211 @@
+import { motion } from 'framer-motion';
+import type { CSSProperties } from 'react';
+
+interface PixelIconProps {
+  className?: string;
+  style?: CSSProperties;
+}
+
+/** Rotating pixel art Triforce for Gaming — always gold */
+export function TriforceIcon({ className, style }: PixelIconProps) {
+  const gold = '#ffd700';
+  return (
+    <motion.svg
+      viewBox="0 0 48 44"
+      className={className}
+      style={{ ...style, color: gold, filter: `drop-shadow(0 0 6px ${gold}40)`, imageRendering: 'pixelated' }}
+      animate={{ rotateY: [0, 360] }}
+      transition={{ duration: 4, repeat: Infinity, ease: 'linear' }}
+    >
+      {/* Top triangle — thicker, bolder */}
+      <polygon points="24,0 36,20 12,20" fill={gold} stroke={gold} strokeWidth="1.5" />
+      {/* Bottom-left triangle */}
+      <polygon points="12,22 24,42 0,42" fill={gold} stroke={gold} strokeWidth="1.5" />
+      {/* Bottom-right triangle */}
+      <polygon points="36,22 48,42 24,42" fill={gold} stroke={gold} strokeWidth="1.5" />
+      {/* Inner void — the negative space triangle */}
+      <polygon points="24,22 30,32 18,32" fill="#0a0e1a" />
+    </motion.svg>
+  );
+}
+
+/** Pixel art cooking pan with flame for Cooking */
+export function PixelPotIcon({ className, style }: PixelIconProps) {
+  return (
+    <svg viewBox="0 0 32 32" className={className} style={{ ...style, imageRendering: 'pixelated' }}>
+      {/* Pan group — wobbles like sizzling */}
+      <motion.g
+        animate={{ x: [0, 0.5, -0.5, 0.3, 0], y: [0, -0.5, 0, -0.3, 0] }}
+        transition={{ duration: 0.6, repeat: Infinity, ease: 'easeInOut' }}
+      >
+        {/* Steam wisps */}
+        <motion.g
+          animate={{ y: [0, -2, 0], opacity: [0.3, 0.7, 0.3] }}
+          transition={{ duration: 2, repeat: Infinity, ease: 'easeInOut' }}
+        >
+          <rect x="11" y="1" width="2" height="2" fill="currentColor" opacity="0.4" />
+          <rect x="15" y="0" width="2" height="2" fill="currentColor" opacity="0.3" />
+          <rect x="19" y="1" width="2" height="2" fill="currentColor" opacity="0.5" />
+        </motion.g>
+        {/* Pan handle */}
+        <rect x="24" y="10" width="7" height="3" fill="currentColor" opacity="0.7" />
+        <rect x="29" y="9" width="2" height="5" fill="currentColor" opacity="0.5" />
+        {/* Pan rim */}
+        <rect x="4" y="7" width="22" height="3" fill="currentColor" />
+        {/* Pan body */}
+        <rect x="5" y="10" width="20" height="10" fill="currentColor" opacity="0.85" />
+        {/* Food inside */}
+        <rect x="7" y="10" width="16" height="4" fill="currentColor" />
+      </motion.g>
+      {/* Flame below — stays still, just flickers */}
+      <rect x="9" y="22" width="3" height="4" fill="#ff3333" opacity="0.8" />
+      <rect x="14" y="21" width="3" height="5" fill="#ffd700" opacity="0.9" />
+      <rect x="19" y="22" width="3" height="4" fill="#ff3333" opacity="0.8" />
+      <motion.g animate={{ opacity: [0.4, 0.8, 0.4] }} transition={{ duration: 1, repeat: Infinity }}>
+        <rect x="11" y="23" width="2" height="3" fill="#ffd700" opacity="0.6" />
+        <rect x="17" y="23" width="2" height="3" fill="#ffd700" opacity="0.6" />
+      </motion.g>
+      {/* Stove grate */}
+      <rect x="6" y="20" width="18" height="2" fill="currentColor" opacity="0.4" />
+    </svg>
+  );
+}
+
+/** Pixel art server rack with blinking LEDs for Homelabbing */
+export function PixelServerIcon({ className, style }: PixelIconProps) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} style={{ ...style, imageRendering: 'pixelated' }}>
+      {/* Rack frame */}
+      <rect x="4" y="2" width="16" height="20" fill="currentColor" opacity="0.8" />
+      {/* Server units */}
+      <rect x="6" y="4" width="12" height="3" fill="#0a0e1a" />
+      <rect x="6" y="9" width="12" height="3" fill="#0a0e1a" />
+      <rect x="6" y="14" width="12" height="3" fill="#0a0e1a" />
+      {/* Blinking LEDs */}
+      <motion.rect
+        x="7" y="5" width="2" height="1"
+        fill="#39ff14"
+        animate={{ opacity: [1, 0.3, 1] }}
+        transition={{ duration: 1.2, repeat: Infinity, delay: 0 }}
+      />
+      <motion.rect
+        x="7" y="10" width="2" height="1"
+        fill="#39ff14"
+        animate={{ opacity: [1, 0.3, 1] }}
+        transition={{ duration: 0.8, repeat: Infinity, delay: 0.3 }}
+      />
+      <motion.rect
+        x="7" y="15" width="2" height="1"
+        fill="#4d8cff"
+        animate={{ opacity: [1, 0.3, 1] }}
+        transition={{ duration: 1.5, repeat: Infinity, delay: 0.6 }}
+      />
+      {/* Drive bays */}
+      <rect x="11" y="5" width="5" height="1" fill="currentColor" opacity="0.3" />
+      <rect x="11" y="10" width="5" height="1" fill="currentColor" opacity="0.3" />
+      <rect x="11" y="15" width="5" height="1" fill="currentColor" opacity="0.3" />
+    </svg>
+  );
+}
+
+/** Pixel art airplane for Traveling — clearer than compass */
+export function PixelCompassIcon({ className, style }: PixelIconProps) {
+  return (
+    <motion.svg
+      viewBox="0 0 32 32"
+      className={className}
+      style={{ ...style, imageRendering: 'pixelated' }}
+      animate={{ y: [0, -3, 0], rotate: [0, 2, -2, 0] }}
+      transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+    >
+      {/* Fuselage */}
+      <rect x="14" y="4" width="4" height="20" fill="currentColor" />
+      <rect x="13" y="6" width="6" height="14" fill="currentColor" />
+      {/* Nose */}
+      <rect x="15" y="2" width="2" height="2" fill="currentColor" />
+      {/* Wings */}
+      <rect x="4" y="12" width="24" height="4" fill="currentColor" />
+      <rect x="6" y="11" width="20" height="2" fill="currentColor" opacity="0.7" />
+      {/* Tail wings */}
+      <rect x="10" y="22" width="12" height="3" fill="currentColor" />
+      {/* Tail fin */}
+      <rect x="15" y="20" width="2" height="6" fill="currentColor" />
+      {/* Windows */}
+      <rect x="15" y="7" width="2" height="1" fill="#00e5ff" opacity="0.8" />
+      <rect x="15" y="9" width="2" height="1" fill="#00e5ff" opacity="0.6" />
+      <rect x="15" y="11" width="2" height="1" fill="#00e5ff" opacity="0.4" />
+      {/* Engine glow */}
+      <motion.rect
+        x="14" y="26" width="4" height="2"
+        fill="#ff3333"
+        animate={{ opacity: [0.3, 0.8, 0.3] }}
+        transition={{ duration: 0.6, repeat: Infinity }}
+      />
+    </motion.svg>
+  );
+}
+
+/** Pixel art coffee cup with steam for Coffee */
+export function PixelCoffeeIcon({ className, style }: PixelIconProps) {
+  return (
+    <svg viewBox="0 0 28 28" className={className} style={{ ...style, imageRendering: 'pixelated' }}>
+      {/* Steam wisps */}
+      <motion.g
+        animate={{ y: [0, -2, 0], opacity: [0.3, 0.7, 0.3] }}
+        transition={{ duration: 2.5, repeat: Infinity, ease: 'easeInOut' }}
+      >
+        <rect x="8" y="2" width="2" height="3" fill="currentColor" opacity="0.4" />
+        <rect x="12" y="0" width="2" height="3" fill="currentColor" opacity="0.3" />
+        <rect x="16" y="1" width="2" height="3" fill="currentColor" opacity="0.5" />
+      </motion.g>
+      {/* Cup body */}
+      <rect x="4" y="7" width="16" height="13" fill="currentColor" />
+      {/* Handle */}
+      <rect x="20" y="9" width="4" height="2" fill="currentColor" />
+      <rect x="22" y="11" width="2" height="4" fill="currentColor" />
+      <rect x="20" y="15" width="4" height="2" fill="currentColor" />
+      {/* Coffee inside */}
+      <rect x="6" y="10" width="12" height="8" fill="#0a0e1a" opacity="0.4" />
+      {/* Coffee surface */}
+      <rect x="6" y="10" width="12" height="2" fill="#d97706" opacity="0.5" />
+      {/* Saucer */}
+      <rect x="2" y="20" width="20" height="3" fill="currentColor" opacity="0.8" />
+      <rect x="4" y="23" width="16" height="2" fill="currentColor" opacity="0.5" />
+    </svg>
+  );
+}
+
+/** Pixel art open book for Reading */
+export function PixelBookIcon({ className, style }: PixelIconProps) {
+  return (
+    <svg viewBox="0 0 28 24" className={className} style={{ ...style, imageRendering: 'pixelated' }}>
+      {/* Left page */}
+      <rect x="1" y="3" width="12" height="17" fill="currentColor" />
+      {/* Right page */}
+      <rect x="15" y="3" width="12" height="17" fill="currentColor" />
+      {/* Spine */}
+      <rect x="13" y="2" width="2" height="19" fill="currentColor" opacity="0.6" />
+      {/* Left page text lines */}
+      <rect x="3" y="6" width="8" height="1" fill="#0a0e1a" opacity="0.5" />
+      <rect x="3" y="8" width="7" height="1" fill="#0a0e1a" opacity="0.5" />
+      <rect x="3" y="10" width="8" height="1" fill="#0a0e1a" opacity="0.5" />
+      <rect x="3" y="12" width="5" height="1" fill="#0a0e1a" opacity="0.5" />
+      <rect x="3" y="14" width="7" height="1" fill="#0a0e1a" opacity="0.5" />
+      {/* Right page text lines */}
+      <rect x="17" y="6" width="8" height="1" fill="#0a0e1a" opacity="0.5" />
+      <rect x="17" y="8" width="6" height="1" fill="#0a0e1a" opacity="0.5" />
+      <rect x="17" y="10" width="8" height="1" fill="#0a0e1a" opacity="0.5" />
+      <rect x="17" y="12" width="7" height="1" fill="#0a0e1a" opacity="0.5" />
+      {/* Animated reading sparkle */}
+      <motion.rect
+        x="18" y="14" width="2" height="2"
+        fill="#ffd700"
+        animate={{ opacity: [0, 1, 0] }}
+        transition={{ duration: 2, repeat: Infinity, delay: 1 }}
+      />
+      {/* Cover edges for depth */}
+      <rect x="0" y="2" width="1" height="19" fill="currentColor" opacity="0.4" />
+      <rect x="27" y="2" width="1" height="19" fill="currentColor" opacity="0.4" />
+    </svg>
+  );
+}

--- a/app/src/components/ui/PixelIcons.tsx
+++ b/app/src/components/ui/PixelIcons.tsx
@@ -109,7 +109,7 @@ export function PixelServerIcon({ className, style }: PixelIconProps) {
 }
 
 /** Pixel art airplane for Traveling — clearer than compass */
-export function PixelCompassIcon({ className, style }: PixelIconProps) {
+export function PixelPlaneIcon({ className, style }: PixelIconProps) {
   return (
     <motion.svg
       viewBox="0 0 32 32"

--- a/app/src/components/ui/StatBar.tsx
+++ b/app/src/components/ui/StatBar.tsx
@@ -1,4 +1,5 @@
-import { motion } from 'framer-motion';
+import { useState } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
 
 interface StatBarProps {
   label: string;
@@ -9,28 +10,44 @@ interface StatBarProps {
 }
 
 const colorMap = {
-  green: { fill: '#39ff14', bg: '#0a2e06', glow: 'rgba(57,255,20,0.2)' },
-  blue: { fill: '#4d8cff', bg: '#0a1a3e', glow: 'rgba(77,140,255,0.2)' },
-  gold: { fill: '#ffd700', bg: '#2e2a06', glow: 'rgba(255,215,0,0.2)' },
-  magenta: { fill: '#ff2daa', bg: '#2e0620', glow: 'rgba(255,45,170,0.2)' },
-  cyan: { fill: '#00e5ff', bg: '#062e33', glow: 'rgba(0,229,255,0.2)' },
+  green: { fill: '#39ff14', bg: '#0a2e06', glow: 'rgba(57,255,20,0.2)', glowStrong: 'rgba(57,255,20,0.4)' },
+  blue: { fill: '#4d8cff', bg: '#0a1a3e', glow: 'rgba(77,140,255,0.2)', glowStrong: 'rgba(77,140,255,0.4)' },
+  gold: { fill: '#ffd700', bg: '#2e2a06', glow: 'rgba(255,215,0,0.2)', glowStrong: 'rgba(255,215,0,0.4)' },
+  magenta: { fill: '#ff2daa', bg: '#2e0620', glow: 'rgba(255,45,170,0.2)', glowStrong: 'rgba(255,45,170,0.4)' },
+  cyan: { fill: '#00e5ff', bg: '#062e33', glow: 'rgba(0,229,255,0.2)', glowStrong: 'rgba(0,229,255,0.4)' },
 };
 
 function StatBar({ label, level, maxLevel = 100, color = 'green', delay = 0 }: StatBarProps) {
   const c = colorMap[color];
   const pct = Math.min((level / maxLevel) * 100, 100);
+  const [hovered, setHovered] = useState(false);
+  const reducedMotion = useReducedMotion();
 
   return (
-    <div className="space-y-1">
+    <div
+      className="space-y-1 group"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
       <div className="flex items-baseline justify-between">
         <span className="font-body text-sm text-rpg-text">{label}</span>
-        <span className="font-pixel text-[9px] text-rpg-text-dim">
+        <motion.span
+          className="font-pixel text-[9px]"
+          animate={{
+            color: hovered ? c.fill : '#6b7fa3',
+            textShadow: hovered ? `0 0 8px ${c.glow}` : '0 0 0px transparent',
+          }}
+          transition={{ duration: 0.2 }}
+        >
           Lv.{level}
-        </span>
+        </motion.span>
       </div>
       <div
-        className="h-4 relative border border-rpg-border overflow-hidden"
-        style={{ backgroundColor: c.bg }}
+        className="h-4 relative border border-rpg-border overflow-hidden transition-all duration-200"
+        style={{
+          backgroundColor: c.bg,
+          boxShadow: hovered ? `0 0 12px ${c.glowStrong}, inset 0 0 8px ${c.glow}` : 'none',
+        }}
         role="progressbar"
         aria-valuenow={level}
         aria-valuemin={0}
@@ -38,8 +55,9 @@ function StatBar({ label, level, maxLevel = 100, color = 'green', delay = 0 }: S
         aria-label={label}
       >
         <motion.div
-          initial={{ width: 0 }}
-          animate={{ width: `${pct}%` }}
+          initial={reducedMotion ? { width: `${pct}%` } : { width: 0 }}
+          whileInView={{ width: `${pct}%` }}
+          viewport={{ once: true, margin: '-40px' }}
           transition={{ duration: 1, delay, ease: 'easeOut' }}
           className="h-full stat-shimmer relative"
           style={{
@@ -54,6 +72,21 @@ function StatBar({ label, level, maxLevel = 100, color = 'green', delay = 0 }: S
             backgroundImage: 'repeating-linear-gradient(90deg, transparent, transparent 3px, rgba(0,0,0,0.3) 3px, rgba(0,0,0,0.3) 4px)',
           }}
         />
+        {/* Hover notch markers */}
+        {hovered && (
+          <div className="absolute inset-0 pointer-events-none">
+            {[25, 50, 75].map((mark) => (
+              <motion.div
+                key={mark}
+                className="absolute top-0 h-full w-px"
+                style={{ left: `${mark}%`, backgroundColor: `${c.fill}33` }}
+                initial={{ opacity: 0, scaleY: 0 }}
+                animate={{ opacity: 1, scaleY: 1 }}
+                transition={{ duration: 0.15, delay: (mark / 100) * 0.1 }}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/app/src/hooks/useKonamiCode.ts
+++ b/app/src/hooks/useKonamiCode.ts
@@ -8,10 +8,12 @@ const KONAMI_SEQUENCE = [
   'b', 'a',
 ];
 
-export function useKonamiCode() {
+export function useKonamiCode(onActivate?: () => void) {
   const [activated, setActivated] = useState(false);
   const indexRef = useRef(0);
   const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const onActivateRef = useRef(onActivate);
+  onActivateRef.current = onActivate;
 
   const reset = useCallback(() => {
     indexRef.current = 0;
@@ -30,6 +32,8 @@ export function useKonamiCode() {
 
         if (indexRef.current === KONAMI_SEQUENCE.length) {
           clearTimeout(timerRef.current);
+          // Call synchronously within the keydown gesture for audio policy
+          onActivateRef.current?.();
           setActivated(true);
           reset();
         }

--- a/app/src/hooks/useZeldaSecret.ts
+++ b/app/src/hooks/useZeldaSecret.ts
@@ -11,58 +11,61 @@ export function useZeldaSecret() {
   const ctxRef = useRef<AudioContext | null>(null);
 
   const play = useCallback(() => {
-    if (!AudioCtx) return;
+    try {
+      if (!AudioCtx) return;
 
-    const ctx = ctxRef.current ?? new AudioCtx();
-    ctxRef.current = ctx;
-    if (ctx.state === 'suspended') {
-      ctx.resume();
+      const ctx = ctxRef.current ?? new AudioCtx();
+      ctxRef.current = ctx;
+      if (ctx.state === 'suspended') {
+        ctx.resume();
+      }
+
+      // Classic "secret discovered" notes (frequencies in Hz)
+      const notes: [number, number, number][] = [
+        [587.33, 0.0, 0.12],    // D5
+        [622.25, 0.12, 0.12],   // Eb5
+        [659.25, 0.24, 0.12],   // E5
+        [698.46, 0.36, 0.12],   // F5
+        [739.99, 0.48, 0.12],   // F#5
+        [783.99, 0.60, 0.12],   // G5
+        [830.61, 0.72, 0.12],   // Ab5
+        [880.00, 0.84, 0.12],   // A5
+        [932.33, 0.96, 0.12],   // Bb5
+        [987.77, 1.08, 0.35],   // B5 (held longer)
+      ];
+
+      const masterGain = ctx.createGain();
+      masterGain.gain.setValueAtTime(0.18, ctx.currentTime);
+      masterGain.connect(ctx.destination);
+
+      const lastNote = notes[notes.length - 1];
+      const totalDuration = lastNote[1] + lastNote[2] + 0.1;
+
+      notes.forEach(([freq, start, dur]) => {
+        const osc = ctx.createOscillator();
+        osc.type = 'square';
+        osc.frequency.setValueAtTime(freq, ctx.currentTime + start);
+
+        const gain = ctx.createGain();
+        gain.gain.setValueAtTime(0, ctx.currentTime + start);
+        gain.gain.linearRampToValueAtTime(0.7, ctx.currentTime + start + 0.01);
+        gain.gain.setValueAtTime(0.7, ctx.currentTime + start + dur * 0.6);
+        gain.gain.exponentialRampToValueAtTime(0.01, ctx.currentTime + start + dur);
+
+        osc.connect(gain);
+        gain.connect(masterGain);
+
+        osc.start(ctx.currentTime + start);
+        osc.stop(ctx.currentTime + start + dur + 0.05);
+      });
+
+      // Disconnect master gain after playback to avoid building up the audio graph
+      setTimeout(() => {
+        masterGain.disconnect();
+      }, totalDuration * 1000 + 200);
+    } catch {
+      // Non-critical: overlay still displays, just no sound
     }
-
-    // Classic "secret discovered" notes (frequencies in Hz)
-    const notes: [number, number, number][] = [
-      // [frequency, startTime, duration]
-      [587.33, 0.0, 0.12],    // D5
-      [622.25, 0.12, 0.12],   // Eb5
-      [659.25, 0.24, 0.12],   // E5
-      [698.46, 0.36, 0.12],   // F5
-      [739.99, 0.48, 0.12],   // F#5
-      [783.99, 0.60, 0.12],   // G5
-      [830.61, 0.72, 0.12],   // Ab5
-      [880.00, 0.84, 0.12],   // A5
-      [932.33, 0.96, 0.12],   // Bb5
-      [987.77, 1.08, 0.35],   // B5 (held longer)
-    ];
-
-    const masterGain = ctx.createGain();
-    masterGain.gain.setValueAtTime(0.18, ctx.currentTime);
-    masterGain.connect(ctx.destination);
-
-    const lastNote = notes[notes.length - 1];
-    const totalDuration = lastNote[1] + lastNote[2] + 0.1;
-
-    notes.forEach(([freq, start, dur]) => {
-      const osc = ctx.createOscillator();
-      osc.type = 'square';
-      osc.frequency.setValueAtTime(freq, ctx.currentTime + start);
-
-      const gain = ctx.createGain();
-      gain.gain.setValueAtTime(0, ctx.currentTime + start);
-      gain.gain.linearRampToValueAtTime(0.7, ctx.currentTime + start + 0.01);
-      gain.gain.setValueAtTime(0.7, ctx.currentTime + start + dur * 0.6);
-      gain.gain.exponentialRampToValueAtTime(0.01, ctx.currentTime + start + dur);
-
-      osc.connect(gain);
-      gain.connect(masterGain);
-
-      osc.start(ctx.currentTime + start);
-      osc.stop(ctx.currentTime + start + dur + 0.05);
-    });
-
-    // Disconnect master gain after playback to avoid building up the audio graph
-    setTimeout(() => {
-      masterGain.disconnect();
-    }, totalDuration * 1000 + 200);
   }, []);
 
   return play;

--- a/app/src/hooks/useZeldaSecret.ts
+++ b/app/src/hooks/useZeldaSecret.ts
@@ -1,0 +1,57 @@
+import { useCallback, useRef } from 'react';
+
+/**
+ * Programmatically generates the classic Zelda "secret discovered" jingle
+ * using the Web Audio API — no external audio files needed.
+ * Notes approximate the iconic ascending arpeggio from the original game.
+ */
+export function useZeldaSecret() {
+  const ctxRef = useRef<AudioContext | null>(null);
+
+  const play = useCallback(() => {
+    const ctx = ctxRef.current ?? new AudioContext();
+    ctxRef.current = ctx;
+
+    // Classic "secret discovered" notes (frequencies in Hz)
+    // Approximation of the Zelda secret jingle: ascending arpeggio
+    const notes: [number, number, number][] = [
+      // [frequency, startTime, duration]
+      [587.33, 0.0, 0.12],    // D5
+      [622.25, 0.12, 0.12],   // Eb5
+      [659.25, 0.24, 0.12],   // E5
+      [698.46, 0.36, 0.12],   // F5
+      [739.99, 0.48, 0.12],   // F#5
+      [783.99, 0.60, 0.12],   // G5
+      [830.61, 0.72, 0.12],   // Ab5
+      [880.00, 0.84, 0.12],   // A5
+      [932.33, 0.96, 0.12],   // Bb5
+      [987.77, 1.08, 0.35],   // B5 (held longer)
+    ];
+
+    const masterGain = ctx.createGain();
+    masterGain.gain.setValueAtTime(0.18, ctx.currentTime);
+    masterGain.connect(ctx.destination);
+
+    notes.forEach(([freq, start, dur]) => {
+      // Square wave for that 8-bit chiptune character
+      const osc = ctx.createOscillator();
+      osc.type = 'square';
+      osc.frequency.setValueAtTime(freq, ctx.currentTime + start);
+
+      // Envelope for each note
+      const gain = ctx.createGain();
+      gain.gain.setValueAtTime(0, ctx.currentTime + start);
+      gain.gain.linearRampToValueAtTime(0.7, ctx.currentTime + start + 0.01);
+      gain.gain.setValueAtTime(0.7, ctx.currentTime + start + dur * 0.6);
+      gain.gain.exponentialRampToValueAtTime(0.01, ctx.currentTime + start + dur);
+
+      osc.connect(gain);
+      gain.connect(masterGain);
+
+      osc.start(ctx.currentTime + start);
+      osc.stop(ctx.currentTime + start + dur + 0.05);
+    });
+  }, []);
+
+  return play;
+}

--- a/app/src/hooks/useZeldaSecret.ts
+++ b/app/src/hooks/useZeldaSecret.ts
@@ -1,5 +1,7 @@
 import { useCallback, useRef } from 'react';
 
+const AudioCtx = window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+
 /**
  * Programmatically generates the classic Zelda "secret discovered" jingle
  * using the Web Audio API — no external audio files needed.
@@ -9,14 +11,15 @@ export function useZeldaSecret() {
   const ctxRef = useRef<AudioContext | null>(null);
 
   const play = useCallback(() => {
-    const ctx = ctxRef.current ?? new AudioContext();
+    if (!AudioCtx) return;
+
+    const ctx = ctxRef.current ?? new AudioCtx();
     ctxRef.current = ctx;
     if (ctx.state === 'suspended') {
       ctx.resume();
     }
 
     // Classic "secret discovered" notes (frequencies in Hz)
-    // Approximation of the Zelda secret jingle: ascending arpeggio
     const notes: [number, number, number][] = [
       // [frequency, startTime, duration]
       [587.33, 0.0, 0.12],    // D5
@@ -35,13 +38,14 @@ export function useZeldaSecret() {
     masterGain.gain.setValueAtTime(0.18, ctx.currentTime);
     masterGain.connect(ctx.destination);
 
+    const lastNote = notes[notes.length - 1];
+    const totalDuration = lastNote[1] + lastNote[2] + 0.1;
+
     notes.forEach(([freq, start, dur]) => {
-      // Square wave for that 8-bit chiptune character
       const osc = ctx.createOscillator();
       osc.type = 'square';
       osc.frequency.setValueAtTime(freq, ctx.currentTime + start);
 
-      // Envelope for each note
       const gain = ctx.createGain();
       gain.gain.setValueAtTime(0, ctx.currentTime + start);
       gain.gain.linearRampToValueAtTime(0.7, ctx.currentTime + start + 0.01);
@@ -54,6 +58,11 @@ export function useZeldaSecret() {
       osc.start(ctx.currentTime + start);
       osc.stop(ctx.currentTime + start + dur + 0.05);
     });
+
+    // Disconnect master gain after playback to avoid building up the audio graph
+    setTimeout(() => {
+      masterGain.disconnect();
+    }, totalDuration * 1000 + 200);
   }, []);
 
   return play;

--- a/app/src/hooks/useZeldaSecret.ts
+++ b/app/src/hooks/useZeldaSecret.ts
@@ -11,6 +11,9 @@ export function useZeldaSecret() {
   const play = useCallback(() => {
     const ctx = ctxRef.current ?? new AudioContext();
     ctxRef.current = ctx;
+    if (ctx.state === 'suspended') {
+      ctx.resume();
+    }
 
     // Classic "secret discovered" notes (frequencies in Hz)
     // Approximation of the Zelda secret jingle: ascending arpeggio

--- a/app/src/pages/Hobbies.tsx
+++ b/app/src/pages/Hobbies.tsx
@@ -1,12 +1,24 @@
 import type { ComponentType, CSSProperties } from 'react';
 import PageTransition from '../components/PageTransition';
-import { Gamepad2, ChefHat, Server, Plane, Coffee, BookOpen } from 'lucide-react';
 import { motion } from 'framer-motion';
 import hobbiesContent from '@resources/hobbies_content.json';
 import PixelPanel from '../components/ui/PixelPanel';
+import {
+  TriforceIcon,
+  PixelPotIcon,
+  PixelServerIcon,
+  PixelCompassIcon,
+  PixelCoffeeIcon,
+  PixelBookIcon,
+} from '../components/ui/PixelIcons';
 
 const iconMap: Record<string, ComponentType<{ className?: string; style?: CSSProperties }>> = {
-  Gamepad2, ChefHat, Server, Plane, Coffee, BookOpen,
+  Gamepad2: TriforceIcon,
+  ChefHat: PixelPotIcon,
+  Server: PixelServerIcon,
+  Plane: PixelCompassIcon,
+  Coffee: PixelCoffeeIcon,
+  BookOpen: PixelBookIcon,
 };
 
 const colorMap: Record<string, string> = {
@@ -16,6 +28,7 @@ const colorMap: Record<string, string> = {
   'text-blue-500': '#4d8cff',
   'text-yellow-500': '#ffd700',
   'text-amber-700': '#d97706',
+  'text-gray-400': '#9ca3af',
 };
 
 function Hobbies() {

--- a/app/src/pages/Hobbies.tsx
+++ b/app/src/pages/Hobbies.tsx
@@ -46,7 +46,13 @@ function Hobbies() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {hobbiesContent.hobbies.map((hobby, index) => {
             const IconComponent = iconMap[hobby.icon];
+            if (import.meta.env.DEV && !IconComponent) {
+              console.warn(`Hobbies: No icon mapped for "${hobby.icon}". Available: ${Object.keys(iconMap).join(', ')}`);
+            }
             const color = colorMap[hobby.iconColor] || '#c8d6e5';
+            if (import.meta.env.DEV && !colorMap[hobby.iconColor]) {
+              console.warn(`Hobbies: No color mapped for "${hobby.iconColor}". Available: ${Object.keys(colorMap).join(', ')}`);
+            }
 
             return (
               <motion.div

--- a/app/src/pages/Hobbies.tsx
+++ b/app/src/pages/Hobbies.tsx
@@ -7,7 +7,7 @@ import {
   TriforceIcon,
   PixelPotIcon,
   PixelServerIcon,
-  PixelCompassIcon,
+  PixelPlaneIcon,
   PixelCoffeeIcon,
   PixelBookIcon,
 } from '../components/ui/PixelIcons';
@@ -16,7 +16,7 @@ const iconMap: Record<string, ComponentType<{ className?: string; style?: CSSPro
   Gamepad2: TriforceIcon,
   ChefHat: PixelPotIcon,
   Server: PixelServerIcon,
-  Plane: PixelCompassIcon,
+  Plane: PixelPlaneIcon,
   Coffee: PixelCoffeeIcon,
   BookOpen: PixelBookIcon,
 };

--- a/app/src/test/setup.ts
+++ b/app/src/test/setup.ts
@@ -1,5 +1,16 @@
 import '@testing-library/jest-dom';
 
+// Mock IntersectionObserver for framer-motion whileInView
+class MockIntersectionObserver {
+  observe = () => {};
+  unobserve = () => {};
+  disconnect = () => {};
+}
+Object.defineProperty(window, 'IntersectionObserver', {
+  writable: true,
+  value: MockIntersectionObserver,
+});
+
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: (query: string) => ({

--- a/resources/hobbies_content.json
+++ b/resources/hobbies_content.json
@@ -3,7 +3,7 @@
     {
       "title": "Homelabbing",
       "icon": "Server",
-      "iconColor": "text-green-500",
+      "iconColor": "text-gray-400",
       "description": "Running a personal homelab for experimenting with new technologies, self-hosting services, and learning about infrastructure management."
     },
     {


### PR DESCRIPTION
## Summary
- **Skill bars**: Scroll-triggered fill animation with `whileInView`, hover glow effect with level text highlight and 25/50/75% notch markers
- **Custom pixel art hobby icons**: Rotating golden Triforce (gaming), sizzling pan on flame (cooking), grey server rack with blinking LEDs (homelabbing), bobbing airplane (traveling), steaming coffee cup, and open book with sparkle
- **Konami code overhaul**: Replaced confetti with Zelda "secret discovered" spotlight — cross-shaped light pillar, radial gold burst, diamond sparkles, and pixel particles. Plays a chiptune jingle via Web Audio API (no external audio files)

## Test plan
- [x] Build passes
- [x] All 15 tests pass (added IntersectionObserver mock for whileInView)
- [ ] Verify skill bars animate on scroll into view
- [ ] Verify hover glow + notch markers on stat bars
- [ ] Check all 6 hobby icons render with animations on /hobbies
- [ ] Test Konami code (↑↑↓↓←→←→BA) triggers Zelda spotlight + sound
- [ ] Verify sound plays correctly in Chrome/Firefox/Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)