### PR TITLE
Fix Trivy CI failure: downgrade action and guard SARIF upload

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -110,7 +110,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
           format: "sarif"
@@ -119,6 +119,6 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
-        if: always()
+        if: always() && hashFiles('trivy-results.sarif') != ''
         with:
           sarif_file: "trivy-results.sarif"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -110,7 +110,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
           format: "sarif"


### PR DESCRIPTION
## Summary
- Downgrade `aquasecurity/trivy-action` from `0.34.0` to `0.28.0` — the newer version exits with code 1 before running the scan, producing no SARIF output
- Guard the SARIF upload step with `hashFiles('trivy-results.sarif') != ''` so it gracefully skips when the file is missing instead of failing the job

Fixes: https://github.com/jgarcesres/resume/actions/runs/23269605794/job/67659039076

## Test plan
- [ ] CI pipeline passes on merge to main
- [ ] Trivy scan produces SARIF output and uploads to Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)