### PR TITLE
Add networking, storage, AI/LLM skills and homelab project

### DIFF
--- a/app/src/components/SkillTree.tsx
+++ b/app/src/components/SkillTree.tsx
@@ -35,6 +35,8 @@ const CATEGORY_COLORS: Record<string, string> = {
   monitoring: '#39ff14',
   security: '#ff2daa',
   languages: '#ff8c00',
+  networking: '#e74cff',
+  ai: '#ff6b6b',
 };
 
 function getCategoryColor(category: string): string {

--- a/resources/projects_content.json
+++ b/resources/projects_content.json
@@ -3,7 +3,23 @@
     {
       "public": [
         {
-          
+          "title": "homelab",
+          "description": "A geo-distributed GitOps homelab spanning Florida and Medellin, Colombia. Runs a K3s cluster across two sites connected via Tailscale mesh VPN, with full ArgoCD App of Apps GitOps, Cilium CNI, Proxmox virtualization, and a complete observability stack.",
+          "githubUrl": "https://github.com/jgarcesres/homelab",
+          "technologies": ["K3s", "ArgoCD", "Tailscale", "Cilium", "Proxmox", "Helm", "OpenTofu", "Grafana", "Prometheus", "Loki"],
+          "features": [
+            "Multi-site Kubernetes cluster across two countries with Tailscale site-to-site VPN",
+            "GitOps-driven with ArgoCD App of Apps pattern and auto-discovery",
+            "Cilium eBPF CNI with native routing and kube-proxy replacement",
+            "Proxmox VMs managed via OpenTofu infrastructure-as-code",
+            "Full observability stack: Prometheus, Grafana, Loki, AlertManager",
+            "1Password Operator for Kubernetes-native secrets management",
+            "Tailscale VIP Services via ProxyGroups and Gateway API HTTPRoutes for external ingress",
+            "~140TB raw storage across TrueNAS (ZFS), Synology NAS, NFS CSI, and Democratic CSI (iSCSI)"
+          ]
+        },
+        {
+
           "title": "resume",
           "description": "this resume is defined in github and deployed through github actions to a static site hosted on my homelab. The resume is built using React and Tailwind CSS, and the content is managed through JSON files.",
           "githubUrl": "https://github.com/jgarcesres/resume",

--- a/resources/skill_tree.json
+++ b/resources/skill_tree.json
@@ -6,6 +6,8 @@
     { "id": "aws", "label": "AWS", "category": "cloud", "level": 95, "description": "EC2, EKS, Lambda, S3, RDS, IAM, CloudFormation" },
     { "id": "azure", "label": "Azure", "category": "cloud", "level": 85, "description": "AKS, Azure AD, managed services" },
     { "id": "terraform", "label": "Terraform", "category": "cloud", "level": 92, "description": "Infrastructure as Code across multi-cloud" },
+    { "id": "opentofu", "label": "OpenTofu", "category": "cloud", "level": 90, "description": "Open-source Terraform fork, Proxmox VM management" },
+    { "id": "proxmox", "label": "Proxmox", "category": "cloud", "level": 85, "description": "Hypervisor clustering, VM lifecycle, ZFS storage" },
 
     { "id": "containers", "label": "Containers", "category": "devops", "level": 93, "description": "Container orchestration and runtime" },
     { "id": "kubernetes", "label": "Kubernetes", "category": "devops", "level": 90, "description": "EKS, AKS, k3s — production cluster management" },
@@ -21,6 +23,16 @@
     { "id": "prometheus", "label": "Prometheus", "category": "monitoring", "level": 90, "description": "Metrics collection, PromQL, recording rules" },
     { "id": "mimir", "label": "Mimir", "category": "monitoring", "level": 82, "description": "Long-term metrics storage at scale" },
     { "id": "pagerduty", "label": "PagerDuty", "category": "monitoring", "level": 88, "description": "On-call rotations, incident management" },
+    { "id": "loki", "label": "Loki", "category": "monitoring", "level": 85, "description": "Log aggregation, LogQL queries" },
+
+    { "id": "networking", "label": "Networking", "category": "networking", "level": 88, "description": "VPN, CNI, DNS, and certificate management" },
+    { "id": "tailscale", "label": "Tailscale", "category": "networking", "level": 90, "description": "Mesh VPN, ACL policy-as-code, site-to-site" },
+    { "id": "cilium", "label": "Cilium", "category": "networking", "level": 85, "description": "eBPF CNI, native routing, kube-proxy replacement" },
+    { "id": "cloudflare", "label": "Cloudflare", "category": "networking", "level": 85, "description": "DNS management, DDNS, proxy configuration" },
+
+    { "id": "ai", "label": "AI/LLM", "category": "ai", "level": 80, "description": "AI tooling, local models, and agent infrastructure" },
+    { "id": "mcp", "label": "MCP", "category": "ai", "level": 82, "description": "Model Context Protocol servers and gateways" },
+    { "id": "ollama", "label": "Ollama", "category": "ai", "level": 78, "description": "Local LLM hosting and inference" },
 
     { "id": "security", "label": "Security", "category": "security", "level": 85, "description": "Identity, access control, and compliance" },
     { "id": "okta", "label": "Okta", "category": "security", "level": 88, "description": "SSO, MFA, lifecycle management" },
@@ -42,12 +54,16 @@
     { "from": "root", "to": "containers" },
     { "from": "root", "to": "cicd" },
     { "from": "root", "to": "observability" },
+    { "from": "root", "to": "networking" },
+    { "from": "root", "to": "ai" },
     { "from": "root", "to": "security" },
     { "from": "root", "to": "languages" },
 
     { "from": "cloud", "to": "aws" },
     { "from": "cloud", "to": "azure" },
     { "from": "cloud", "to": "terraform" },
+    { "from": "cloud", "to": "opentofu" },
+    { "from": "cloud", "to": "proxmox" },
     { "from": "cloud", "to": "databases" },
     { "from": "databases", "to": "postgres" },
     { "from": "databases", "to": "redis" },
@@ -62,6 +78,7 @@
     { "from": "observability", "to": "grafana" },
     { "from": "observability", "to": "prometheus" },
     { "from": "observability", "to": "mimir" },
+    { "from": "observability", "to": "loki" },
     { "from": "observability", "to": "pagerduty" },
 
     { "from": "security", "to": "okta" },
@@ -73,10 +90,21 @@
     { "from": "languages", "to": "bash" },
     { "from": "languages", "to": "powershell" },
 
+    { "from": "networking", "to": "tailscale" },
+    { "from": "networking", "to": "cilium" },
+    { "from": "networking", "to": "cloudflare" },
+
+    { "from": "ai", "to": "mcp" },
+    { "from": "ai", "to": "ollama" },
+
     { "from": "kubernetes", "to": "argocd" },
+    { "from": "kubernetes", "to": "cilium" },
+    { "from": "kubernetes", "to": "tailscale" },
     { "from": "prometheus", "to": "grafana" },
+    { "from": "loki", "to": "grafana" },
     { "from": "terraform", "to": "aws" },
     { "from": "terraform", "to": "azure" },
+    { "from": "opentofu", "to": "proxmox" },
     { "from": "okta", "to": "saml" }
   ]
 }

--- a/resources/structured_resume.json
+++ b/resources/structured_resume.json
@@ -95,22 +95,47 @@
       "GCP",
       "Azure",
       "Terraform",
+      "OpenTofu",
       "Kubernetes",
+      "K3s",
       "Docker",
-      "Ansible"
+      "Helm",
+      "Ansible",
+      "Proxmox"
+    ],
+    "networking": [
+      "Tailscale",
+      "Cilium",
+      "Gateway API",
+      "Cloudflare",
+      "external-dns",
+      "cert-manager",
+      "CoreDNS"
     ],
     "ci/cd": [
       "GitLab CI",
       "GitHub Actions",
-      "argoCD"
+      "ArgoCD"
     ],
     "observability": [
       "Datadog",
       "Grafana",
       "Prometheus",
+      "Loki",
       "Mimir",
+      "PromQL",
+      "LogQL",
       "Alertmanager",
       "PagerDuty"
+    ],
+    "storage": [
+      "TrueNAS",
+      "ZFS",
+      "NFS",
+      "iSCSI",
+      "Synology",
+      "NFS CSI",
+      "Democratic CSI"
     ],
     "operating_systems": [
       "Linux",
@@ -126,15 +151,19 @@
     "languages": [
       "Python",
       "Bash",
-      "PowerShell"
+      "PowerShell",
+      "HCL"
     ],
     "spoken_languages": [
       "Native English",
       "Native Spanish"
     ],
     "other": [
-      "AI Prompt Engineering",
+      "MCP (Model Context Protocol)",
+      "Ollama",
+      "AI-Assisted Infrastructure",
       "Hashicorp Vault",
+      "1Password Operator",
       "Git",
       "Data Analysis",
       "Data Visualization",
@@ -145,6 +174,7 @@
       "jamf",
       "SAML",
       "OAuth",
+      "OIDC",
       "RESTful APIs"
     ]
   }

--- a/resources/structured_resume.json
+++ b/resources/structured_resume.json
@@ -4,10 +4,25 @@
   "intro": "Site Reliability Engineer with expertise in DevOps, observability, automation, and infrastructure. I specialize in building robust, scalable systems and streamlining development workflows with a strong background in Security and Identity management.",
   "experience": [
     {
+      "company": "OpenSpace",
+      "role": "Cloud Infrastructure Engineer",
+      "location": "Remote",
+      "dates": "November 2025 \u2013 Present",
+      "summary": "Managing multi-cloud infrastructure across AWS and GCP, supporting Kubernetes clusters spanning multiple global regions.",
+      "responsibilities": [
+        "Manage cloud infrastructure across AWS and GCP with Kubernetes clusters deployed in US, Canada, UK, EU, KSA, Singapore, and Japan.",
+        "Maintain and develop Terraform configurations for infrastructure-as-code across multi-region deployments.",
+        "Handle CI/CD pipeline maintenance and operational PRs for ongoing infrastructure upkeep.",
+        "Participate in on-call rotations and incident response for production systems.",
+        "Contribute to observability efforts using Datadog and Grafana for monitoring and alerting.",
+        "Manage Tailscale-based networking across distributed cloud environments."
+      ]
+    },
+    {
       "company": "Scuba Analytics",
       "role": "Site Reliability Engineer (SRE)",
       "location": "Remote (California/Florida)",
-      "dates": "October 2021 \u2013 Present",
+      "dates": "October 2021 \u2013 April 2025",
       "summary": "Focused on building and maintaining robust infrastructure and CI/CD pipelines. Improved observability for the fleet and automated config management.",
       "responsibilities": [
         "Managed application clusters in AWS and Azure for enterprise clients within their environments (Microsoft, Salesforce, Asana).",
@@ -77,6 +92,7 @@
   "skills_and_technologies": {
     "cloud/devops": [
       "AWS",
+      "GCP",
       "Azure",
       "Terraform",
       "Kubernetes",
@@ -89,6 +105,7 @@
       "argoCD"
     ],
     "observability": [
+      "Datadog",
       "Grafana",
       "Prometheus",
       "Mimir",


### PR DESCRIPTION
## Summary
- **New skill categories:** Networking (Tailscale, Cilium, Gateway API, Cloudflare, external-dns, cert-manager, CoreDNS) and Storage (TrueNAS, ZFS, NFS, iSCSI, Synology, NFS CSI, Democratic CSI)
- **Expanded existing categories:** Cloud/DevOps (+OpenTofu, K3s, Helm, Proxmox), Observability (+Loki, PromQL, LogQL), Security (+1Password Operator, OIDC), Languages (+HCL)
- **Updated AI section:** Replaced generic "AI Prompt Engineering" with MCP (Model Context Protocol), Ollama, and AI-Assisted Infrastructure
- **New skill tree branches:** Networking and AI/LLM with cross-links to Kubernetes, plus Loki, OpenTofu, Proxmox nodes
- **Flagship project:** Added homelab as the first public project — multi-site GitOps K3s cluster across FL and Colombia

## Test plan
- [ ] Verify `structured_resume.json` renders all new skill categories correctly on the Resume page
- [ ] Verify skill tree displays new Networking (purple) and AI/LLM (red) branches with proper colors and legend entries
- [ ] Verify homelab project card appears first in public projects tab with all features listed
- [ ] Check PDF export includes new skill categories
- [ ] Verify no layout issues from increased number of skill categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)