### PR TITLE
Reduce shader overlay intensity

### DIFF
--- a/app/src/components/ShaderOverlay.tsx
+++ b/app/src/components/ShaderOverlay.tsx
@@ -201,7 +201,7 @@ function ShaderOverlay({ preset }: ShaderOverlayProps) {
         uniformData[0] = canvas.width;
         uniformData[1] = canvas.height;
         uniformData[2] = (performance.now() - startTimeRef.current) / 1000;
-        uniformData[3] = 1.0;
+        uniformData[3] = 0.7;
         uniformData[4] = canvas.clientWidth || window.innerWidth;
 
         gpu.device.queue.writeBuffer(gpu.uniformBuffer, 0, uniformData);


### PR DESCRIPTION
## Summary

- Reduce WebGPU shader intensity uniform from \`1.0\` → \`0.7\` across all presets (CRT, bloom, chromatic, retro, matrix)

## What changed

Single line in \`ShaderOverlay.tsx\`: \`uniformData[3] = 0.7\`. Scales all per-effect coefficients in the \`.wgsl\` files uniformly — scanlines, phosphor dots, vignette, flicker, scan band, edge glow, bloom glows, and chromatic fringes all become 30% subtler.

## iOS 26 glass UI note

Attempted a fix for the iOS 26 glass UI coverage issue (\`inset: 0\` + \`getBoundingClientRect\` + visualViewport scroll listener), but it regressed desktop coverage and caused mobile crashes from scroll-event thrashing. Reverted. The iOS 26 coverage issue remains open and will need a separate targeted fix once reproducible.

## Test plan

- [ ] All shader presets look subtler on desktop (CRT, bloom, chromatic, retro, matrix)
- [ ] No regressions — presets still switch correctly via ShaderSelector dropdown
- [ ] Desktop shader still covers the full viewport
- [ ] No crashes on mobile Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)